### PR TITLE
Use GitHub App for release commits

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -77,6 +77,13 @@ jobs:
     needs: [build-windows, build-macos, build-linux]
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
 
       - name: Generate version
@@ -120,10 +127,10 @@ jobs:
 
       - name: Commit and tag
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "Aloy the Cat[bot]"
+          git config user.email "aloy-the-cat[bot]@users.noreply.github.com"
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git
           git add Package/Plugins/ Package/package.json
           if git diff --staged --quiet; then


### PR DESCRIPTION
- Uses Aloy the Cat app instead of PAT
- Allows bypassing branch protection without admin access