### PR TITLE
Pass App token to checkout action for proper git auth

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -85,6 +85,8 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Generate version
         id: version


### PR DESCRIPTION
## Summary
- Pass App token to `actions/checkout@v4` so git is configured with the correct credentials from the start
- Fixes branch protection bypass not working because checkout was using the default GITHUB_TOKEN

## Root cause
The `actions/checkout@v4` action configures git credentials with the default `GITHUB_TOKEN`, which doesn't have bypass permissions. Even though we set the remote URL later, the checkout action's credential configuration persists.

## Fix
Pass our App token to checkout via the `token` parameter, ensuring git is configured correctly from the start.

Reference: https://github.com/orgs/community/discussions/136531

## Test plan
- [ ] Merge this PR and verify CI pushes the release commit successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)