### PR TITLE
Checkout main branch explicitly in release job

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -87,6 +87,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
+          ref: main
 
       - name: Generate version
         id: version


### PR DESCRIPTION
## Summary
- Add `ref: main` to checkout step in release job
- Fixes non-fast-forward push rejection after PR merge

## Root cause
For `pull_request` events, `actions/checkout@v4` defaults to checking out the PR merge ref (`refs/pull/XX/merge`), not the actual main branch. This causes:

1. CI checks out synthetic merge ref (different SHA than actual main)
2. Release commit is created on top of synthetic merge
3. Push to main fails because parent SHA doesn't match

## Fix
Explicitly checkout `main` branch so the release commit has the correct parent.

## Test plan
- [ ] Merge this PR and verify release commit pushes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)