### PR TITLE
Add badges and release v1.0.0

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -92,18 +92,9 @@ jobs:
       - name: Generate version
         id: version
         run: |
-          # Read current version from package.json
-          CURRENT=$(grep -o '"version": "[^"]*"' Package/package.json | cut -d'"' -f4)
-
-          # Parse major.minor.patch
-          MAJOR=$(echo $CURRENT | cut -d. -f1)
-          MINOR=$(echo $CURRENT | cut -d. -f2)
-          PATCH=$(echo $CURRENT | cut -d. -f3)
-
-          # Increment patch
-          PATCH=$((PATCH + 1))
-
-          VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          # One-time: Release 1.0.0
+          # TODO: Revert to auto-increment after this release
+          VERSION="1.0.0"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Download Windows artifact

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Unity MCP - AI Assistant Integration for Unity Editor
 
+![Unity 6+](https://img.shields.io/badge/Unity-6%2B-black?logo=unity)
+![License](https://img.shields.io/github/license/Bluepuff71/UnityMCP)
+![Release](https://img.shields.io/github/v/tag/Bluepuff71/UnityMCP?label=version)
+![Build](https://img.shields.io/github/actions/workflow/status/Bluepuff71/UnityMCP/build-release.yml?branch=main)
+![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-blue)
+
 Model Context Protocol (MCP) server that enables AI assistants like Claude, Codex, and Cursor to automate Unity Editor tasks and game development workflows.
 
 ## Features
@@ -30,7 +36,7 @@ https://github.com/Bluepuff71/UnityMCP.git?path=/Package
 
 To install a specific version, append `#version` tag:
 ```
-https://github.com/Bluepuff71/UnityMCP.git?path=/Package#0.1.0
+https://github.com/Bluepuff71/UnityMCP.git?path=/Package#1.0.0
 ```
 
 See [Releases](https://github.com/Bluepuff71/UnityMCP/releases) for available versions.


### PR DESCRIPTION
## Summary
- Add badges to README (Unity, License, Release, Build, Platform)
- Update version example to 1.0.0
- Release version 1.0.0

## Badges added
![Unity 6+](https://img.shields.io/badge/Unity-6%2B-black?logo=unity)
![License](https://img.shields.io/github/license/Bluepuff71/UnityMCP)
![Release](https://img.shields.io/github/v/tag/Bluepuff71/UnityMCP?label=version)
![Build](https://img.shields.io/github/actions/workflow/status/Bluepuff71/UnityMCP/build-release.yml?branch=main)
![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-blue)

## Note
The version generation is temporarily hardcoded to 1.0.0. After this PR merges, a follow-up PR will restore auto-increment behavior.

## Test plan
- [ ] Verify badges render correctly on GitHub
- [ ] Verify release 1.0.0 is created after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)