### PR TITLE
fix(plugins): add missing meta files for Linux and macOS native plugins

### DIFF
--- a/Package/Plugins/Linux/x86_64/libUnityMCPProxy.so.meta
+++ b/Package/Plugins/Linux/x86_64/libUnityMCPProxy.so.meta
@@ -1,0 +1,45 @@
+fileFormatVersion: 2
+guid: fccf5416321aae14e85e56b6a60cd55c
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux64: 0
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+  - first:
+      Any:
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+        DefaultValueInitialized: true
+        OS: Linux
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Package/Plugins/macOS/UnityMCPProxy.bundle.meta
+++ b/Package/Plugins/macOS/UnityMCPProxy.bundle.meta
@@ -1,0 +1,45 @@
+fileFormatVersion: 2
+guid: 7ddb2ecdffafb144ab471bf2084a8288
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 0
+        Exclude Win: 1
+        Exclude Win64: 1
+  - first:
+      Any:
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: OSX
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary

- Add missing `.meta` files for `libUnityMCPProxy.so` (Linux) and `UnityMCPProxy.bundle` (macOS)
- Configure proper `PluginImporter` settings for each platform

## Problem

When installing the package via git URL or npm, users on Linux and macOS would see:

```
Asset Packages/com.emeryporter.unitymcp/Plugins/Linux/x86_64/libUnityMCPProxy.so has no meta file, but it's in an immutable folder. The asset will be ignored.

Asset Packages/com.emeryporter.unitymcp/Plugins/macOS/UnityMCPProxy.bundle has no meta file, but it's in an immutable folder. The asset will be ignored.
```

The native plugins were being ignored because Unity cannot auto-generate meta files in the immutable `Packages/` folder.

## Root Cause

The `.meta` files were generated locally but never committed to git, so they weren't included in package distribution.

## Test plan

- [ ] Install package via git URL on Linux - verify `libUnityMCPProxy.so` is recognized
- [ ] Install package via git URL on macOS - verify `UnityMCPProxy.bundle` is recognized
- [ ] Verify no "immutable folder" warnings appear in Unity console

🤖 Generated with [Claude Code](https://claude.com/claude-code)