### PR TITLE
feat: add verbose logging option to reduce console noise

### DIFF
--- a/Package/Editor/Core/MCPServer.cs
+++ b/Package/Editor/Core/MCPServer.cs
@@ -118,7 +118,7 @@ namespace UnityMCP.Editor.Core
             // If native proxy is handling HTTP, don't start managed server
             if (NativeProxy.IsInitialized)
             {
-                Debug.Log("[MCPServer] Native proxy is active, skipping managed HTTP server.");
+                if (NativeProxy.VerboseLogging) Debug.Log("[MCPServer] Native proxy is active, skipping managed HTTP server.");
                 MCPServerDomainReload.SetShouldRun(true, _port);
                 return;
             }
@@ -137,7 +137,7 @@ namespace UnityMCP.Editor.Core
                 // Enable running in background so server responds when Unity is not focused
                 Application.runInBackground = true;
 
-                Debug.Log($"[MCPServer] Started on http://localhost:{_port}/");
+                if (NativeProxy.VerboseLogging) Debug.Log($"[MCPServer] Started on http://localhost:{_port}/");
 
                 ListenAsync(_cancellationTokenSource.Token);
             }
@@ -181,7 +181,7 @@ namespace UnityMCP.Editor.Core
                 MCPServerDomainReload.SetShouldRun(false, _port);
             }
 
-            Debug.Log("[MCPServer] Stopped.");
+            if (NativeProxy.VerboseLogging) Debug.Log("[MCPServer] Stopped.");
         }
 
         private async void ListenAsync(CancellationToken cancellationToken)

--- a/Package/Editor/Core/NativeProxy.cs
+++ b/Package/Editor/Core/NativeProxy.cs
@@ -63,6 +63,12 @@ namespace UnityMCP.Editor.Core
         public static bool IsInitialized => s_initialized;
 
         /// <summary>
+        /// Gets or sets whether verbose logging is enabled.
+        /// When false, only warnings and errors are logged.
+        /// </summary>
+        public static bool VerboseLogging { get; set; } = false;
+
+        /// <summary>
         /// Starts the native proxy server.
         /// </summary>
         public static void Start()
@@ -87,7 +93,7 @@ namespace UnityMCP.Editor.Core
             {
                 RegisterCallback(null);
                 StopServer();
-                Debug.Log("[NativeProxy] Native MCP proxy stopped");
+                if (VerboseLogging) Debug.Log("[NativeProxy] Native MCP proxy stopped");
             }
             catch (Exception exception)
             {
@@ -141,7 +147,7 @@ namespace UnityMCP.Editor.Core
                 Application.runInBackground = true;
 
                 s_initialized = true;
-                Debug.Log($"[NativeProxy] Native MCP proxy initialized on port {DEFAULT_PORT}");
+                if (VerboseLogging) Debug.Log($"[NativeProxy] Native MCP proxy initialized on port {DEFAULT_PORT}");
             }
             catch (DllNotFoundException dllException)
             {

--- a/Package/Editor/Core/ResourceRegistry.cs
+++ b/Package/Editor/Core/ResourceRegistry.cs
@@ -75,7 +75,7 @@ namespace UnityMCP.Editor.Core
 
             _isInitialized = true;
             int totalResources = _resources.Count + _parameterizedResources.Count;
-            Debug.Log($"[ResourceRegistry] Discovered {totalResources} MCP resources ({_resources.Count} static, {_parameterizedResources.Count} parameterized)");
+            if (NativeProxy.VerboseLogging) Debug.Log($"[ResourceRegistry] Discovered {totalResources} MCP resources ({_resources.Count} static, {_parameterizedResources.Count} parameterized)");
         }
 
         private static void DiscoverResourcesInAssembly(Assembly assembly)

--- a/Package/Editor/Core/ToolRegistry.cs
+++ b/Package/Editor/Core/ToolRegistry.cs
@@ -70,7 +70,7 @@ namespace UnityMCP.Editor.Core
             }
 
             _isInitialized = true;
-            Debug.Log($"[ToolRegistry] Discovered {_tools.Count} MCP tools");
+            if (NativeProxy.VerboseLogging) Debug.Log($"[ToolRegistry] Discovered {_tools.Count} MCP tools");
         }
 
         private static void DiscoverToolsInAssembly(Assembly assembly)

--- a/Package/Editor/UI/MCPServerWindow.cs
+++ b/Package/Editor/UI/MCPServerWindow.cs
@@ -19,6 +19,7 @@ namespace UnityMCP.Editor.UI
         private Dictionary<string, bool> _categoryFoldouts = new Dictionary<string, bool>();
 
         private const string DocumentationUrl = "https://github.com/anthropics/anthropic-cookbook/tree/main/misc/model_context_protocol";
+        private const string VerboseLoggingPrefKey = "UnityMCP_VerboseLogging";
 
         [MenuItem("Window/Unity MCP")]
         public static void ShowWindow()
@@ -30,6 +31,7 @@ namespace UnityMCP.Editor.UI
         private void OnEnable()
         {
             _portInput = MCPServer.Instance.Port;
+            NativeProxy.VerboseLogging = EditorPrefs.GetBool(VerboseLoggingPrefKey, false);
         }
 
         /// <summary>
@@ -148,7 +150,7 @@ namespace UnityMCP.Editor.UI
             if (GUILayout.Button("Copy", GUILayout.Width(50)))
             {
                 EditorGUIUtility.systemCopyBuffer = endpoint;
-                Debug.Log($"[MCPServerWindow] Copied endpoint to clipboard: {endpoint}");
+                if (NativeProxy.VerboseLogging) Debug.Log($"[MCPServerWindow] Copied endpoint to clipboard: {endpoint}");
             }
             EditorGUILayout.EndHorizontal();
 
@@ -181,7 +183,7 @@ namespace UnityMCP.Editor.UI
                 if (_portInput > 0 && _portInput <= 65535)
                 {
                     MCPServer.Instance.Port = _portInput;
-                    Debug.Log($"[MCPServerWindow] Port changed to {_portInput}");
+                    if (NativeProxy.VerboseLogging) Debug.Log($"[MCPServerWindow] Port changed to {_portInput}");
                 }
                 else
                 {
@@ -197,6 +199,15 @@ namespace UnityMCP.Editor.UI
             }
 
             EditorGUI.EndDisabledGroup();
+
+            // Verbose logging toggle (always enabled)
+            EditorGUILayout.Space(4);
+            bool verboseLogging = EditorGUILayout.Toggle("Verbose Logging", NativeProxy.VerboseLogging);
+            if (verboseLogging != NativeProxy.VerboseLogging)
+            {
+                NativeProxy.VerboseLogging = verboseLogging;
+                EditorPrefs.SetBool(VerboseLoggingPrefKey, verboseLogging);
+            }
 
             EditorGUI.indentLevel--;
         }
@@ -312,7 +323,7 @@ namespace UnityMCP.Editor.UI
             try
             {
                 ToolRegistry.RefreshTools();
-                Debug.Log("[MCPServerWindow] Tools refreshed");
+                if (NativeProxy.VerboseLogging) Debug.Log("[MCPServerWindow] Tools refreshed");
             }
             catch (Exception exception)
             {


### PR DESCRIPTION
Add VerboseLogging flag to gate info-level logs. Warnings and errors remain unconditional. Toggle available in Window > Unity MCP under Configuration section, persisted via EditorPrefs.