### PR TITLE
Fix prolonged 'recompiling' state after compilation request

### DIFF
--- a/Package/Editor/Core/NativeProxy.cs
+++ b/Package/Editor/Core/NativeProxy.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
 using UnityEditor;
-using UnityEditor.Compilation;
 using UnityEngine;
 
 namespace UnityMCP.Editor.Core
@@ -88,7 +87,6 @@ namespace UnityMCP.Editor.Core
             }
 
             AssemblyReloadEvents.beforeAssemblyReload -= OnBeforeReload;
-            CompilationPipeline.compilationStarted -= OnCompilationStarted;
             EditorApplication.quitting -= OnQuit;
 
             try
@@ -143,7 +141,6 @@ namespace UnityMCP.Editor.Core
 
                 // Register for domain unload to safely unregister callback before C# code becomes invalid
                 AssemblyReloadEvents.beforeAssemblyReload += OnBeforeReload;
-                CompilationPipeline.compilationStarted += OnCompilationStarted;
                 EditorApplication.quitting += OnQuit;
 
                 // Enable running in background so server responds when Unity is not focused
@@ -185,23 +182,6 @@ namespace UnityMCP.Editor.Core
         }
 
         /// <summary>
-        /// Called when compilation starts, before domain reload.
-        /// Unregisters the callback early to prevent race conditions during domain reload.
-        /// </summary>
-        private static void OnCompilationStarted(object context)
-        {
-            try
-            {
-                RegisterCallback(null);
-                if (VerboseLogging) Debug.Log("[NativeProxy] Callback unregistered due to compilation start");
-            }
-            catch (Exception exception)
-            {
-                Debug.LogWarning($"[NativeProxy] Error unregistering callback on compilation: {exception.Message}");
-            }
-        }
-
-        /// <summary>
         /// Called when the Unity Editor is quitting.
         /// Cleans up by unregistering the callback and stopping the native server.
         /// </summary>
@@ -209,7 +189,6 @@ namespace UnityMCP.Editor.Core
         {
             try
             {
-                CompilationPipeline.compilationStarted -= OnCompilationStarted;
                 RegisterCallback(null);
                 StopServer();
             }


### PR DESCRIPTION
## Summary

- Removes `OnCompilationStarted` handler that caused MCP calls to fail for 30+ seconds during compilation
- Fixes regression introduced in PR #16

## Problem

PR #16 added an `OnCompilationStarted` handler that unregistered the callback when compilation started. This caused:

1. `unity_refresh(compile=request)` triggers `CompilationPipeline.RequestScriptCompilation()`
2. **Immediately** `OnCompilationStarted` fires → callback unregistered
3. All MCP calls return "Unity is recompiling" error
4. This persists for the **entire compilation duration** (30+ seconds on Unity 6+)

## Solution

Remove the `OnCompilationStarted` handler. The ThreadAbortException protection from PR #16 still works via:

| Layer | Protection | Status |
|-------|------------|--------|
| C# `finally` block | Sends error response during ThreadAbortException | ✅ Kept |
| Native fail-safe | Returns error if callback completes without response | ✅ Kept |
| `OnCompilationStarted` | Early callback unregistration | ❌ Removed |

The callback now stays registered until `OnBeforeReload` (actual domain reload), minimizing the unavailability window.

## Test plan

- [ ] Call `unity_refresh(compile=request)` then immediately call `console_read`
- [ ] Should work during compilation (before domain reload starts)
- [ ] During domain reload, should get brief "interrupted" error then recover

🤖 Generated with [Claude Code](https://claude.com/claude-code)