### PR TITLE
Fix native server restart on package updates

### DIFF
--- a/NativeProxy~/proxy.h
+++ b/NativeProxy~/proxy.h
@@ -79,6 +79,14 @@ EXPORT int IsServerRunning(void);
  */
 EXPORT int IsCallbackValid(void);
 
+/*
+ * Get the process ID of this native library instance.
+ * Used to verify if an existing server belongs to the same process.
+ *
+ * @return The process ID as an unsigned long
+ */
+EXPORT unsigned long GetNativeProcessId(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Summary

- Adds internal endpoints for server management (`/__internal/info`, `/__internal/shutdown`)
- Implements graceful shutdown of old DLL instance during package updates
- Uses process ID verification to avoid shutting down other Unity instances' servers

## Problem

When updating the UnityMCP package via Package Manager:

1. Old DLL is at `Library/PackageCache/com.emeryporter.unitymcp@OLD_HASH/...`
2. Old DLL has server running on port 8080
3. New DLL loads from `Library/PackageCache/com.emeryporter.unitymcp@NEW_HASH/...`
4. **These are different file paths** - both DLLs can be loaded simultaneously
5. New DLL's `StartServer()` fails to bind port 8080 → falls back to managed server
6. **Requires Unity restart** to fix

## Solution

### Native side (proxy.c)

Added two internal endpoints:

| Endpoint | Method | Response |
|----------|--------|----------|
| `/__internal/info` | GET | `{"server":"UnityMCPProxy","pid":12345,"running":1}` |
| `/__internal/shutdown` | GET | `{"success":true,"message":"Shutdown requested"}` |

The server thread now checks for shutdown requests and cleans up gracefully.

### C# side (NativeProxy.cs)

When `StartServer()` fails with "port in use":

1. Query `/__internal/info` on localhost:8080
2. Parse the process ID from response
3. **Only if same PID** (meaning it's our old DLL, not another Unity instance):
   - Send `/__internal/shutdown` request
   - Wait briefly
   - Retry `StartServer()`

## Safety

- **Won't affect other Unity instances**: Only shuts down server if PID matches
- **Timeout protection**: 2-second timeout on HTTP requests
- **Retry logic**: Up to 3 retries with 100ms delay between each
- **Graceful fallback**: If all else fails, falls back to managed server

## Test plan

- [ ] Fresh Unity start - server starts normally
- [ ] Domain reload (script change) - server survives, callback re-registers
- [ ] Package update - old server shuts down, new server starts
- [ ] Two Unity instances - each keeps its own server (or one falls back)

## Note

**Native DLL must be rebuilt** after merging for the fix to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)