### PR TITLE
fix: resolve compilation errors - PackageInfo ambiguity and missing .…

### DIFF
--- a/Package/Editor/Attributes/MCPPromptAttribute.cs.meta
+++ b/Package/Editor/Attributes/MCPPromptAttribute.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 242646bdd4f44c66842a5df152e16ec0

--- a/Package/Editor/Core/MCPServer.cs
+++ b/Package/Editor/Core/MCPServer.cs
@@ -10,7 +10,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
-using UnityEditor.PackageManager;
 using UnityMCP.Editor.Utilities;
 
 namespace UnityMCP.Editor.Core
@@ -58,7 +57,7 @@ namespace UnityMCP.Editor.Core
         private CancellationTokenSource _cancellationTokenSource;
         private int _port = 8080;
         private const string ServerName = "UnityMCP";
-        private static readonly string ServerVersion = PackageInfo.FindForAssembly(typeof(MCPServer).Assembly)?.version ?? "1.3.0";
+        private static readonly string ServerVersion = UnityEditor.PackageManager.PackageInfo.FindForAssembly(typeof(MCPServer).Assembly)?.version ?? "1.3.0";
         private const int MainThreadTimeoutSeconds = 30;
 
         /// <summary>

--- a/Package/Editor/Core/PromptRegistry.cs.meta
+++ b/Package/Editor/Core/PromptRegistry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: eb2301df9b2f4774b8f3733ccb8e2a81

--- a/Package/Editor/Prompts.meta
+++ b/Package/Editor/Prompts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 856eadc5f8e84b109f7ab1a06db5de07
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Package/Editor/Prompts/UnityPrompts.cs.meta
+++ b/Package/Editor/Prompts/UnityPrompts.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9283c54056c7478f8ecb4d2ffe1e8505

--- a/Package/Editor/Tools/SearchTools.cs.meta
+++ b/Package/Editor/Tools/SearchTools.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d2c28d9c11564bb8a6e44c23e0a116ca


### PR DESCRIPTION
…meta files

- Fully qualify UnityEditor.PackageManager.PackageInfo to resolve ambiguity with UnityEditor.PackageInfo
- Remove unused 'using UnityEditor.PackageManager' import
- Add .meta files for all new files so Unity recognizes them in immutable package cache folders (MCPPromptAttribute, PromptRegistry, Prompts folder, UnityPrompts, SearchTools)