### PR TITLE
Detect stale plugin after package update

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -14,80 +14,15 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build-windows:
-    runs-on: windows-latest
-    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Build Windows DLL
-        shell: bash
-        run: |
-          cd Proxy~
-          gcc -shared -O2 -DNDEBUG -DMG_ENABLE_LINES=0 \
-            proxy.c mongoose.c \
-            -o UnityMCPProxy.dll \
-            -lws2_32
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: windows-plugin
-          path: Proxy~/UnityMCPProxy.dll
-
-  build-macos:
-    runs-on: macos-latest
-    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Build macOS Bundle (Universal)
-        run: |
-          cd Proxy~
-          clang -shared -O2 -DNDEBUG -DMG_ENABLE_LINES=0 \
-            proxy.c mongoose.c \
-            -o UnityMCPProxy.bundle \
-            -arch arm64 -arch x86_64 \
-            -framework CoreFoundation -framework Security
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: macos-plugin
-          path: Proxy~/UnityMCPProxy.bundle
-
-  build-linux:
+  version:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
-
-      - name: Build Linux Shared Library
-        run: |
-          cd Proxy~
-          gcc -shared -fPIC -O2 -DNDEBUG -DMG_ENABLE_LINES=0 \
-            proxy.c mongoose.c \
-            -o libUnityMCPProxy.so \
-            -lpthread
-
-      - uses: actions/upload-artifact@v4
         with:
-          name: linux-plugin
-          path: Proxy~/libUnityMCPProxy.so
-
-  release:
-    needs: [build-windows, build-macos, build-linux]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Generate App token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-          ref: main
+          fetch-tags: true
 
       - name: Generate version
         id: version
@@ -121,6 +56,84 @@ jobs:
           echo "Selected version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
+  build-windows:
+    needs: [version]
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Windows DLL
+        shell: bash
+        run: |
+          cd Proxy~
+          gcc -shared -O2 -DNDEBUG -DMG_ENABLE_LINES=0 \
+            -DPROXY_VERSION="\"${{ needs.version.outputs.version }}\"" \
+            proxy.c mongoose.c \
+            -o UnityMCPProxy.dll \
+            -lws2_32
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-plugin
+          path: Proxy~/UnityMCPProxy.dll
+
+  build-macos:
+    needs: [version]
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build macOS Bundle (Universal)
+        run: |
+          cd Proxy~
+          clang -shared -O2 -DNDEBUG -DMG_ENABLE_LINES=0 \
+            -DPROXY_VERSION="\"${{ needs.version.outputs.version }}\"" \
+            proxy.c mongoose.c \
+            -o UnityMCPProxy.bundle \
+            -arch arm64 -arch x86_64 \
+            -framework CoreFoundation -framework Security
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: macos-plugin
+          path: Proxy~/UnityMCPProxy.bundle
+
+  build-linux:
+    needs: [version]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Linux Shared Library
+        run: |
+          cd Proxy~
+          gcc -shared -fPIC -O2 -DNDEBUG -DMG_ENABLE_LINES=0 \
+            -DPROXY_VERSION="\"${{ needs.version.outputs.version }}\"" \
+            proxy.c mongoose.c \
+            -o libUnityMCPProxy.so \
+            -lpthread
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-plugin
+          path: Proxy~/libUnityMCPProxy.so
+
+  release:
+    needs: [version, build-windows, build-macos, build-linux]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          ref: main
+
       - name: Download Windows artifact
         uses: actions/download-artifact@v4
         with:
@@ -141,7 +154,7 @@ jobs:
 
       - name: Update version strings
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
+          VERSION="${{ needs.version.outputs.version }}"
           sed -i 's/"version": "[^"]*"/"version": "'"$VERSION"'"/' Package/package.json
           sed -i 's/const string ServerVersion = "[^"]*"/const string ServerVersion = "'"$VERSION"'"/' Package/Editor/Core/MCPServer.cs
 
@@ -161,7 +174,7 @@ jobs:
           if git diff --staged --quiet; then
             echo "No changes to commit, skipping release"
           else
-            VERSION="${{ steps.version.outputs.version }}"
+            VERSION="${{ needs.version.outputs.version }}"
 
             # Check if tag already exists
             if git rev-parse "$VERSION" >/dev/null 2>&1; then

--- a/Package/Editor/Core/MCPServer.cs
+++ b/Package/Editor/Core/MCPServer.cs
@@ -19,7 +19,7 @@ namespace UnityMCP.Editor.Core
 
         private int _port = 8080;
         private const string ServerName = "UnityMCP";
-        private const string ServerVersion = "1.4.0";
+        internal const string ServerVersion = "1.4.0";
         private const int MainThreadTimeoutSeconds = 30;
 
         /// <summary>

--- a/Package/Editor/UI/MCPServerWindow.cs
+++ b/Package/Editor/UI/MCPServerWindow.cs
@@ -45,6 +45,11 @@ namespace UnityMCP.Editor.UI
 
         private void OnGUI()
         {
+            if (MCPProxy.NeedsRestart)
+            {
+                DrawRestartBanner();
+            }
+
             DrawToolbar();
 
             EditorGUILayout.Space(8);
@@ -193,6 +198,20 @@ namespace UnityMCP.Editor.UI
             }
 
             EditorGUI.indentLevel--;
+        }
+
+        private void DrawRestartBanner()
+        {
+            EditorGUILayout.HelpBox(
+                "Unity MCP has been updated. Restart the editor to load the new version.",
+                MessageType.Warning);
+
+            if (GUILayout.Button("Restart Editor"))
+            {
+                EditorApplication.OpenProject(System.IO.Directory.GetCurrentDirectory());
+            }
+
+            EditorGUILayout.Space(4);
         }
 
         private void DrawErrorMessage()

--- a/Proxy~/proxy.c
+++ b/Proxy~/proxy.c
@@ -519,15 +519,24 @@ EXPORT unsigned long GetNativeProcessId(void)
 }
 
 /*
+ * Get the version string embedded at compile time.
+ */
+EXPORT const char* GetProxyVersion(void)
+{
+    return PROXY_VERSION;
+}
+
+/*
  * DLL/shared library unload cleanup.
  *
- * When Unity reloads the plugin (e.g. package update), the old DLL is
- * unloaded while its server thread may still be running. Without cleanup, the
- * listen socket leaks and the new DLL can never bind to the same port.
+ * Called when the process exits (DLL_PROCESS_DETACH / destructor).
+ * Note: Unity never unloads native plugins during the editor session —
+ * they persist until the editor process exits.
  *
- * We signal the thread to stop and give it time to close sockets. We cannot
- * call WaitForSingleObject/pthread_join here (loader lock on Windows), so a
- * brief sleep lets the thread's 10ms poll loop notice and run cleanup.
+ * We signal the server thread to stop and give it time to close sockets.
+ * We cannot call WaitForSingleObject/pthread_join here (loader lock on
+ * Windows), so a brief sleep lets the thread's 10ms poll loop notice
+ * and run cleanup.
  */
 #ifdef _WIN32
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)

--- a/Proxy~/proxy.h
+++ b/Proxy~/proxy.h
@@ -28,6 +28,15 @@ extern "C" {
 /*
  * Configuration constants
  */
+/*
+ * Version string embedded at compile time.
+ * CI passes -DPROXY_VERSION="x.y.z" during build.
+ * Defaults to "dev" for local development builds.
+ */
+#ifndef PROXY_VERSION
+#define PROXY_VERSION "dev"
+#endif
+
 #define PROXY_MAX_RESPONSE_SIZE 262144  /* 256KB */
 #define PROXY_MAX_REQUEST_SIZE 262144   /* 256KB */
 #define PROXY_REQUEST_TIMEOUT_MS 30000
@@ -96,6 +105,14 @@ EXPORT int IsPollerActive(void);
  * @return The process ID as an unsigned long
  */
 EXPORT unsigned long GetNativeProcessId(void);
+
+/*
+ * Get the version string embedded at compile time.
+ * Used by C# to detect version mismatch after a package update.
+ *
+ * @return Static string pointer (e.g., "1.4.0" or "dev")
+ */
+EXPORT const char* GetProxyVersion(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary

- Embeds a version string in the native DLL at compile time (`GetProxyVersion()`)
- On startup, compares native DLL version against C# package version
- If they mismatch (package updated but editor not restarted), shows a console warning and a restart banner in the editor window with a "Restart Editor" button
- Removes the old retry-based workaround (`Thread.Sleep` in static constructor) since Unity never unloads native plugins mid-session
- Extracts CI version generation into its own job so build jobs can embed the version

## Test plan

- [ ] Verify normal startup shows no warning
- [ ] Simulate version mismatch (change `ServerVersion` const) and verify console warning + editor window banner appear
- [ ] Verify "Restart Editor" button works
- [ ] Verify CI workflow builds with `-DPROXY_VERSION` on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)