### PR TITLE
Fix missing .meta files causing 18 compilation errors

### DIFF
--- a/Package/Editor/Core/ActivityLog.cs.meta
+++ b/Package/Editor/Core/ActivityLog.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6
+guid: 1b0249c558a14937948629408a4a5cab

--- a/Package/Editor/Core/CertificateGenerator.cs.meta
+++ b/Package/Editor/Core/CertificateGenerator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f55bf713a3ab48df9c10ad146238825b

--- a/Package/Editor/Core/NetworkUtils.cs.meta
+++ b/Package/Editor/Core/NetworkUtils.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3d96809f46504a1fa71a5e63298c7c3c


### PR DESCRIPTION
## Summary

- **ActivityLog.cs.meta** had placeholder GUID `a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6` that conflicted with `TestJobManager.cs.meta` — Unity ignored the file
- **CertificateGenerator.cs** and **NetworkUtils.cs** were committed without `.meta` files — Unity ignores unrecognized assets in immutable package folders
- Generated unique GUIDs for all three meta files, resolving all 18 CS0103/CS8130/CS0019 errors

## Test plan

- [ ] Open Unity project that references this package
- [ ] Verify no compilation errors in Console
- [ ] Verify MCP server window opens and Activity section works
- [ ] Verify Remote Access section shows TLS certificate status

🤖 Generated with [Claude Code](https://claude.com/claude-code)