### PR TITLE
fix: check version mismatch before attempting to bind port

### DIFF
--- a/Package/Editor/Core/MCPProxy.cs
+++ b/Package/Editor/Core/MCPProxy.cs
@@ -266,6 +266,15 @@ namespace UnityMCP.Editor.Core
 
             try
             {
+                // Check for version mismatch before starting the server.
+                // During a package update the old native DLL still holds the port,
+                // so StartServer would fail with a confusing bind error.
+                CheckVersionMismatch();
+                if (NeedsRestart)
+                {
+                    return;
+                }
+
                 // Configure remote access before starting the server
                 ApplyRemoteAccessConfig();
 
@@ -288,9 +297,6 @@ namespace UnityMCP.Editor.Core
                 Application.runInBackground = true;
 
                 s_initialized = true;
-
-                // Check for version mismatch (stale DLL after package update)
-                CheckVersionMismatch();
 
                 if (VerboseLogging) Debug.Log($"[MCPProxy] MCP proxy initialized on port {DEFAULT_PORT}");
             }


### PR DESCRIPTION
## Summary
- During a package update, `CheckVersionMismatch()` ran **after** `StartServer()` in `MCPProxy.Initialize()`
- The old native DLL still holds the port, so `StartServer` would fail and return early — `CheckVersionMismatch()` was never reached
- Users saw a confusing "Failed to bind to port 8080" error instead of the intended "Please restart the Unity Editor" message
- Fix: move `CheckVersionMismatch()` before `StartServer()` and skip server start entirely when a restart is needed

## Test plan
- [ ] Install a version of UnityMCP, then update to a newer version via Package Manager
- [ ] Verify the "Please restart the Unity Editor to complete the update" message appears (not the port bind error)
- [ ] Restart Unity and verify the server starts normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)