### PR TITLE
fix: remove orphaned docs.meta file

### DIFF
--- a/docs.meta
+++ b/docs.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 08ac16088bf32344caead6ee24d21d30
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Removes the orphaned `docs.meta` file from the repository root

## Test plan
- [x] Verify no untracked files remain
- [ ] Confirm Unity project imports cleanly without the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)