### PR TITLE
fix: simplify port binding warning and remove version check

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -67,7 +67,6 @@ jobs:
         run: |
           cd Proxy~
           gcc -shared -O2 -DNDEBUG -DMG_ENABLE_LINES=0 -DMG_TLS=MG_TLS_BUILTIN \
-            -DPROXY_VERSION="\"${{ needs.version.outputs.version }}\"" \
             proxy.c mongoose.c \
             -o UnityMCPProxy.dll \
             -lws2_32
@@ -87,7 +86,6 @@ jobs:
         run: |
           cd Proxy~
           clang -shared -O2 -DNDEBUG -DMG_ENABLE_LINES=0 -DMG_TLS=MG_TLS_BUILTIN \
-            -DPROXY_VERSION="\"${{ needs.version.outputs.version }}\"" \
             proxy.c mongoose.c \
             -o UnityMCPProxy.bundle \
             -arch arm64 -arch x86_64 \
@@ -108,7 +106,6 @@ jobs:
         run: |
           cd Proxy~
           gcc -shared -fPIC -O2 -DNDEBUG -DMG_ENABLE_LINES=0 -DMG_TLS=MG_TLS_BUILTIN \
-            -DPROXY_VERSION="\"${{ needs.version.outputs.version }}\"" \
             proxy.c mongoose.c \
             -o libUnityMCPProxy.so \
             -lpthread

--- a/Package/Editor/UI/MCPServerWindow.cs
+++ b/Package/Editor/UI/MCPServerWindow.cs
@@ -60,11 +60,6 @@ namespace UnityMCP.Editor.UI
 
         private void OnGUI()
         {
-            if (MCPProxy.NeedsRestart)
-            {
-                DrawRestartBanner();
-            }
-
             DrawToolbar();
 
             EditorGUILayout.Space(8);
@@ -231,20 +226,6 @@ namespace UnityMCP.Editor.UI
             }
 
             EditorGUI.indentLevel--;
-        }
-
-        private void DrawRestartBanner()
-        {
-            EditorGUILayout.HelpBox(
-                "Unity MCP has been updated. Restart the editor to load the new version.",
-                MessageType.Warning);
-
-            if (GUILayout.Button("Restart Editor"))
-            {
-                EditorApplication.OpenProject(System.IO.Directory.GetCurrentDirectory());
-            }
-
-            EditorGUILayout.Space(4);
         }
 
         private void DrawErrorMessage()

--- a/Proxy~/proxy.c
+++ b/Proxy~/proxy.c
@@ -581,14 +581,6 @@ EXPORT unsigned long GetNativeProcessId(void)
 }
 
 /*
- * Get the version string embedded at compile time.
- */
-EXPORT const char* GetProxyVersion(void)
-{
-    return PROXY_VERSION;
-}
-
-/*
  * Configure the bind address for the server.
  * Must be called before StartServer(). Defaults to "127.0.0.1".
  */

--- a/Proxy~/proxy.h
+++ b/Proxy~/proxy.h
@@ -28,15 +28,6 @@ extern "C" {
 /*
  * Configuration constants
  */
-/*
- * Version string embedded at compile time.
- * CI passes -DPROXY_VERSION="x.y.z" during build.
- * Defaults to "dev" for local development builds.
- */
-#ifndef PROXY_VERSION
-#define PROXY_VERSION "dev"
-#endif
-
 #define PROXY_MAX_RESPONSE_SIZE 262144  /* 256KB */
 #define PROXY_MAX_REQUEST_SIZE 262144   /* 256KB */
 #define PROXY_REQUEST_TIMEOUT_MS 30000
@@ -105,14 +96,6 @@ EXPORT int IsPollerActive(void);
  * @return The process ID as an unsigned long
  */
 EXPORT unsigned long GetNativeProcessId(void);
-
-/*
- * Get the version string embedded at compile time.
- * Used by C# to detect version mismatch after a package update.
- *
- * @return Static string pointer (e.g., "1.4.0" or "dev")
- */
-EXPORT const char* GetProxyVersion(void);
 
 /*
  * Configure the bind address for the server.


### PR DESCRIPTION
## Summary
- Remove the fragile version-mismatch detection between native DLL and C# package (`CheckVersionMismatch`, `GetProxyVersion`, `PROXY_VERSION`, `NeedsRestart`)
- Update port binding failure warning to cover both update and port-conflict scenarios
- Remove restart banner from the MCPServerWindow UI
- Remove `-DPROXY_VERSION` compiler flag from all CI build steps

## Context
During package updates, `CheckVersionMismatch()` fails to detect the mismatch when the native DLL returns `"dev"` (early-returns without setting `NeedsRestart`). Users see a confusing "Failed to bind to port 8080" warning instead of helpful restart guidance. This removes the fragile detection entirely and improves the warning message.

## Test plan
- [ ] Confirm no compile errors in Unity
- [ ] Confirm proxy starts normally on first launch
- [ ] Confirm improved warning appears when port is already bound
- [ ] Open Window > Unity MCP — confirm no errors
- [ ] Local build scripts (`build_windows.bat`, `build_windows_gcc.bat`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)