### PR TITLE
Remove npx/mcp-remote dependency from Claude Desktop setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,7 @@ Add this to your Claude Desktop configuration file:
 {
   "mcpServers": {
     "unity-mcp": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "http://localhost:8080/"]
+      "url": "http://localhost:8080/"
     }
   }
 }
@@ -89,7 +88,7 @@ Restart Claude Desktop after saving.
 
 ### Other MCP clients (Codex, Cursor, etc.)
 
-Unity MCP exposes a built-in HTTP server at `http://localhost:8080/`. Any MCP-compatible client with HTTP transport support can connect directly. For stdio-only clients, use the `mcp-remote` bridge as shown above.
+Unity MCP exposes a built-in HTTP server at `http://localhost:8080/`. Any MCP-compatible client with Streamable HTTP transport support can connect directly using the URL.
 
 *Note: Configurations for clients other than Claude Code have not been tested. Open a PR!*
 


### PR DESCRIPTION
## Summary
- Replace `npx mcp-remote` bridge with native `url` config for Claude Desktop setup
- Claude Desktop now supports Streamable HTTP transport directly, so the Node.js/npx dependency is no longer needed
- Update "Other MCP clients" section to remove `mcp-remote` reference

## Test plan
- [ ] Verify Claude Desktop connects using the new `url` config
- [ ] Confirm no Node.js/npx is required

🤖 Generated with [Claude Code](https://claude.com/claude-code)