### PR TITLE
fix(asmdef): detect TextMeshPro on Unity 6 where TMP is a core module

### DIFF
--- a/Package/Editor/UnityMCP.Editor.asmdef
+++ b/Package/Editor/UnityMCP.Editor.asmdef
@@ -28,6 +28,11 @@
             "name": "com.unity.textmeshpro",
             "expression": "1.0.0",
             "define": "UNITY_MCP_TMP"
+        },
+        {
+            "name": "Unity",
+            "expression": "6000.0.0",
+            "define": "UNITY_MCP_TMP"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
## Summary
- Unity 6 moved TextMeshPro from a separate package (`com.unity.textmeshpro`) into the engine as a core module
- The asmdef `versionDefines` only checked for the old package name, so `UNITY_MCP_TMP` was never defined on Unity 6
- All TMP element types (`text_tmp`, `button_tmp`, `dropdown_tmp`, `input_field_tmp`) silently fell back to legacy `UnityEngine.UI.Text`
- Fix adds a second `versionDefine` that defines `UNITY_MCP_TMP` for Unity `6000.0.0+`, while preserving the existing package check for pre-Unity 6

## Test plan
- [ ] Open Unity 6 project with TMP available
- [ ] Create `text_tmp` element via `manage_ui_element` — should create `TextMeshProUGUI`, not legacy `Text`
- [ ] Verify no "[UIElementTools] TextMeshPro not available" warnings in console
- [ ] Verify `button_tmp`, `dropdown_tmp`, `input_field_tmp` also create TMP variants
- [ ] Verify `build_ui from_tree` includes TMP types in schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)