### PR TITLE
fix(sessions): move tracking to proxy, remove auto-lock release

### DIFF
--- a/Package/Editor/Core/LockManager.cs
+++ b/Package/Editor/Core/LockManager.cs
@@ -131,31 +131,6 @@ namespace UnityMCP.Editor.Core
         }
 
         /// <summary>
-        /// Releases only auto-acquired locks for a session, preserving manual locks.
-        /// Called after destructive tool execution completes.
-        /// </summary>
-        public static void ReleaseAutoLocks(string sessionId)
-        {
-            bool anyReleased = false;
-
-            lock (s_lock)
-            {
-                var keysToRemove = s_locks
-                    .Where(kvp => kvp.Value.SessionId == sessionId && kvp.Value.IsAutoLock == true)
-                    .Select(kvp => kvp.Key)
-                    .ToList();
-
-                foreach (var key in keysToRemove)
-                    s_locks.Remove(key);
-
-                anyReleased = keysToRemove.Count > 0;
-            }
-
-            if (anyReleased)
-                OnLocksChanged?.Invoke();
-        }
-
-        /// <summary>
         /// Returns a snapshot of locks, optionally filtered by session.
         /// </summary>
         /// <param name="sessionId">If provided, only return locks held by this session.</param>

--- a/Package/Editor/Core/MCPProxy.cs
+++ b/Package/Editor/Core/MCPProxy.cs
@@ -423,6 +423,9 @@ namespace UnityMCP.Editor.Core
         /// <param name="sessionId">The MCP session ID for this request.</param>
         private static void ProcessRequest(int slotId, string jsonRequest, string sessionId)
         {
+            // Track session activity
+            SessionManager.TouchSession(sessionId);
+
             string requestId = ExtractRequestId(jsonRequest);
             string toolName = ExtractToolName(jsonRequest);
             string argumentsSummary = toolName != null ? ExtractArguments(jsonRequest) : null;

--- a/Package/Editor/Core/MCPServer.cs
+++ b/Package/Editor/Core/MCPServer.cs
@@ -160,25 +160,6 @@ COORDINATION: Locks are per-resource (individual GameObjects, files, components)
 
                 JToken paramsToken = requestObject["params"];
 
-                // Session tracking: touch existing sessions or auto-create after domain reload.
-                // Only reject requests with no session ID at all (proxy always provides one
-                // for initialized clients via the Mcp-Session-Id header).
-                if (method != "initialize" && method != "notifications/initialized")
-                {
-                    if (string.IsNullOrEmpty(sessionId))
-                    {
-                        return CreateErrorResponse(MCPErrorCodes.InvalidRequest,
-                            "Missing session ID. Send initialize first.", requestId)
-                            .ToString(Formatting.None);
-                    }
-
-                    if (!SessionManager.TouchSession(sessionId))
-                    {
-                        // Unknown session — likely lost to domain reload. Re-create it.
-                        SessionManager.CreateSession(sessionId);
-                    }
-                }
-
                 JObject response = method switch
                 {
                     "initialize" => HandleInitialize(requestId, sessionId),
@@ -217,8 +198,11 @@ COORDINATION: Locks are per-resource (individual GameObjects, files, components)
 
         private JObject HandleInitialize(string requestId, string sessionId = null)
         {
-            // Create or retrieve session for this agent
-            SessionManager.CreateSession(sessionId);
+            // Create session for this agent if session ID is available
+            if (!string.IsNullOrEmpty(sessionId))
+            {
+                SessionManager.CreateSession(sessionId);
+            }
 
             var result = new JObject
             {
@@ -451,12 +435,6 @@ COORDINATION: Locks are per-resource (individual GameObjects, files, components)
             catch (Exception exception)
             {
                 return CreateSuccessResponse(BuildToolErrorResult($"Tool execution failed: {exception.Message}"), requestId);
-            }
-            finally
-            {
-                // Release auto-acquired locks after tool execution; manual locks persist
-                if (!string.IsNullOrEmpty(sessionId))
-                    LockManager.ReleaseAutoLocks(sessionId);
             }
         }
 

--- a/Package/Editor/Core/SessionManager.cs
+++ b/Package/Editor/Core/SessionManager.cs
@@ -23,7 +23,7 @@ namespace UnityMCP.Editor.Core
         private static readonly Dictionary<string, SessionInfo> s_sessions = new Dictionary<string, SessionInfo>();
         private static readonly object s_lock = new object();
         private const int MaxSessions = 10;
-        private static readonly TimeSpan SessionTimeout = TimeSpan.FromMinutes(15);
+        private static readonly TimeSpan SessionTimeout = TimeSpan.FromMinutes(5);
         private static int s_agentCounter = 0;
 
         /// <summary>Fired when sessions are added or removed. UI subscribes to trigger Repaint.</summary>
@@ -70,23 +70,39 @@ namespace UnityMCP.Editor.Core
 
         /// <summary>
         /// Updates LastActivity and increments RequestCount for the given session.
-        /// Returns false if the session does not exist (caller should reject the request).
+        /// If the session doesn't exist, creates it (handles agents that skip initialize).
         /// </summary>
         /// <param name="sessionId">The session to touch.</param>
-        /// <returns>True if the session was found and updated, false if unknown.</returns>
-        public static bool TouchSession(string sessionId)
+        public static void TouchSession(string sessionId)
         {
+            bool sessionCreated = false;
+
             lock (s_lock)
             {
                 if (s_sessions.TryGetValue(sessionId, out var sessionInfo))
                 {
                     sessionInfo.LastActivity = DateTime.Now;
                     sessionInfo.RequestCount++;
-                    return true;
                 }
-
-                return false;
+                else
+                {
+                    // Auto-create for agents that skip initialize
+                    s_agentCounter++;
+                    var newSession = new SessionInfo
+                    {
+                        SessionId = sessionId,
+                        FriendlyName = $"Agent-{s_agentCounter}",
+                        ConnectTime = DateTime.Now,
+                        LastActivity = DateTime.Now,
+                        RequestCount = 1
+                    };
+                    s_sessions[sessionId] = newSession;
+                    sessionCreated = true;
+                }
             }
+
+            if (sessionCreated)
+                OnSessionsChanged?.Invoke();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

- Move `SessionManager.TouchSession()` into `MCPProxy.ProcessRequest` (earlier in pipeline)
- Remove session validation block from `MCPServer.HandleRequest` — sessions now auto-created by `TouchSession` if unknown
- Remove `ReleaseAutoLocks` from tool execution `finally` block and `LockManager`
- Reduce session timeout from 15 min to 5 min
- `HandleInitialize` only creates session when sessionId is present

## Test plan

- [ ] Verify agents that skip `initialize` still get sessions created
- [ ] Verify manual locks persist after tool execution
- [ ] Verify sessions expire after 5 min of inactivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)