### PR TITLE
feat(sessions): auto-register agent name from MCP initialize clientInfo

### DIFF
--- a/Package/Editor/Core/MCPServer.cs
+++ b/Package/Editor/Core/MCPServer.cs
@@ -181,7 +181,7 @@ COORDINATION: Locks are per-resource (individual GameObjects, files, components)
 
                 JObject response = method switch
                 {
-                    "initialize" => HandleInitialize(requestId, sessionId),
+                    "initialize" => HandleInitialize(paramsToken, requestId, sessionId),
                     "tools/list" => HandleToolsList(requestId),
                     "tools/call" => HandleToolsCall(paramsToken, requestId, sessionId),
                     "resources/list" => HandleResourcesList(requestId),
@@ -215,10 +215,15 @@ COORDINATION: Locks are per-resource (individual GameObjects, files, components)
 
         #region MCP Method Handlers
 
-        private JObject HandleInitialize(string requestId, string sessionId = null)
+        private JObject HandleInitialize(JToken paramsToken, string requestId, string sessionId = null)
         {
             // Create or retrieve session for this agent
             SessionManager.CreateSession(sessionId);
+
+            // Use clientInfo.name from the MCP initialize request as the display name
+            string agentName = paramsToken?["clientInfo"]?["name"]?.ToString();
+            if (!string.IsNullOrEmpty(sessionId) && !string.IsNullOrEmpty(agentName))
+                SessionManager.SetSessionName(sessionId, agentName);
 
             var result = new JObject
             {

--- a/Package/Editor/Core/MCPServer.cs
+++ b/Package/Editor/Core/MCPServer.cs
@@ -222,7 +222,7 @@ COORDINATION: Locks are per-resource (individual GameObjects, files, components)
 
             // Use clientInfo.name from the MCP initialize request as the display name
             string agentName = paramsToken?["clientInfo"]?["name"]?.ToString();
-            if (!string.IsNullOrEmpty(sessionId) && !string.IsNullOrEmpty(agentName))
+            if (!string.IsNullOrEmpty(sessionId) && !string.IsNullOrWhiteSpace(agentName))
                 SessionManager.SetSessionName(sessionId, agentName);
 
             var result = new JObject

--- a/Package/Editor/Core/MCPServer.cs
+++ b/Package/Editor/Core/MCPServer.cs
@@ -220,7 +220,15 @@ COORDINATION: Locks are per-resource (individual GameObjects, files, components)
             // Create or retrieve session for this agent
             SessionManager.CreateSession(sessionId);
 
-            // Use clientInfo.name from the MCP initialize request as the display name
+            // Use clientInfo.name from the MCP initialize request as the display name.
+            // Note: unlike agent_set_name (which rejects whitespace and >32 chars with
+            // MCPException), this path is deliberately more tolerant. Whitespace-only
+            // names fall through the guard below, and names longer than 32 chars are
+            // silently truncated inside SessionManager.SetSessionName. The asymmetry
+            // is intentional: agent_set_name is an explicit user tool that should fail
+            // loud so the caller can correct their input, while auto-registration is a
+            // protocol-level fallback that should preserve as much identifying info as
+            // possible from whatever clientInfo.name the client sends.
             string agentName = paramsToken?["clientInfo"]?["name"]?.ToString();
             if (!string.IsNullOrEmpty(sessionId) && !string.IsNullOrWhiteSpace(agentName))
                 SessionManager.SetSessionName(sessionId, agentName);

--- a/Package/Editor/Core/SessionManager.cs
+++ b/Package/Editor/Core/SessionManager.cs
@@ -183,9 +183,41 @@ namespace UnityMCP.Editor.Core
                 if (name != null && name.Length > 32)
                     name = name.Substring(0, 32);
 
+                if (name != null)
+                    name = DeduplicateName(name, sessionId);
+
                 sessionInfo.FriendlyName = name;
                 return true;
             }
+        }
+
+        /// <summary>
+        /// Appends a numeric suffix if another session already uses the same name.
+        /// Must be called while holding <see cref="s_lock"/>.
+        /// </summary>
+        private static string DeduplicateName(string name, string excludeSessionId)
+        {
+            bool IsTaken(string candidate)
+            {
+                foreach (var kvp in s_sessions)
+                {
+                    if (kvp.Key != excludeSessionId && kvp.Value.FriendlyName == candidate)
+                        return true;
+                }
+                return false;
+            }
+
+            if (!IsTaken(name))
+                return name;
+
+            for (int i = 2; i < 100; i++)
+            {
+                string candidate = $"{name} ({i})";
+                if (!IsTaken(candidate))
+                    return candidate;
+            }
+
+            return name;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- Extracts `clientInfo.name` from the MCP `initialize` request and uses it as the session's display name in the Unity panel (e.g. "Claude Code" instead of "Agent-1")
- Adds name deduplication in `SetSessionName` so duplicate clients get suffixed: "Claude Code", "Claude Code (2)", etc.
- Falls back to the existing "Agent-N" naming if no `clientInfo.name` is provided

## Test plan
- [ ] Connect an MCP client (e.g. Claude Code) and confirm the panel shows its real name instead of "Agent-1"
- [ ] Connect a second client with the same name and confirm it shows "Client Name (2)"
- [ ] Connect a client without `clientInfo.name` and confirm fallback to "Agent-N"
- [ ] Use `agent_set_name` tool and confirm deduplication works there too

https://claude.ai/code/session_01PX5B3Uw1ZhG3Lu1CS58Lo4