### PR TITLE
fix: support Unity 6.0 in UIToolkitTools (EntityIdToObject only exists in 6.1+)

### DIFF
--- a/Package/Editor/Tools/UIToolkitTools.cs
+++ b/Package/Editor/Tools/UIToolkitTools.cs
@@ -1240,7 +1240,14 @@ namespace UnityMCP.Editor.Tools
                     // Scene objects typically have negative instance IDs
                     if (TryConvertToInt(value, out int instanceId))
                     {
+#if UNITY_6000_1_OR_NEWER
+                        // EntityIdToObject was introduced in Unity 6.1 (6000.1) and replaces
+                        // the now-deprecated InstanceIDToObject.
                         newObj = EditorUtility.EntityIdToObject(instanceId);
+#else
+                        // Unity 6.0 (6000.0) and earlier: EntityIdToObject does not exist yet.
+                        newObj = EditorUtility.InstanceIDToObject(instanceId);
+#endif
                         if (newObj != null)
                         {
                             resolvedSource = $"instanceId:{instanceId}";


### PR DESCRIPTION
EditorUtility.EntityIdToObject was introduced in Unity 6.1 (6000.1) and does not exist in Unity 6.0 (6000.0), causing CS0117 there. Guard it with UNITY_6000_1_OR_NEWER and fall back to EditorUtility.InstanceIDToObject on older versions, matching the rest of the package which already uses it.